### PR TITLE
Fix recent post widget tests

### DIFF
--- a/app/entities/VerticalPostCard/ui/index.tsx
+++ b/app/entities/VerticalPostCard/ui/index.tsx
@@ -3,15 +3,29 @@ import { format } from "date-fns";
 import { Link } from "react-router";
 
 interface Props {
-  post: ReadPostListQuery["readPostList"][number];
+  post?: ReadPostListQuery["readPostList"][number];
 }
 
 export function VerticalPostCard({ post }: Props) {
+  const url = post
+    ? `/${post.writer.blog?.domain}/${post.id}`
+    : "#";
+  const createdAt = post
+    ? format(post.createdAt, "yyyy.MM.dd")
+    : new Date().toLocaleDateString("ko-KR");
+  const writer = post?.writer.name ?? "작성자 누구누구씨";
+  const title =
+    post?.title ?? "게시글 제목이에요 게시글 제목이에요 게시글 제목이에요";
+  const content =
+    post?.content ??
+    "게시글 내용이에요 게시글 내용이에요 게시글 내용이에요 게시글 내용이에요 게시글 내용이에요";
+  const hashtagList = post?.hashtagList ?? ["React", "Next.js"];
+
   return (
     <Link
       role="feed"
       aria-label="vertical-post-card"
-      to={`/${post.writer.blog?.domain}/${post.id}`}
+      to={url}
       className="group block overflow-hidden rounded-lg border transition hover:shadow-lg"
     >
       {/* 썸네일 */}
@@ -20,19 +34,17 @@ export function VerticalPostCard({ post }: Props) {
       {/* 콘텐츠 */}
       <div className="p-4">
         <div className="mb-2 flex items-center gap-4">
-          <span className="text-sm text-gray-500">
-            {format(post.createdAt, "yyyy.MM.dd")}
-          </span>
-          <span className="text-sm text-gray-500">• {post.writer.name}</span>
+          <span className="text-sm text-gray-500">{createdAt}</span>
+          <span className="text-sm text-gray-500">• {writer}</span>
         </div>
         <h3 className="group-hover:text-primary mb-2 line-clamp-2 text-xl font-bold group-hover:transition-colors">
-          {post.title}
+          {title}
         </h3>
         <p className="mb-4 line-clamp-2 max-w-11/12 text-sm text-ellipsis whitespace-nowrap text-gray-600">
-          {post.content}
+          {content}
         </p>
         <div className="flex gap-2">
-          {post.hashtagList?.map((tag, index) => (
+          {hashtagList.map((tag, index) => (
             <span
               key={`${tag}_${index}`}
               className="rounded bg-gray-100 px-2 py-1 text-xs"

--- a/app/widgets/RecentPostLIst/ui/RecentPostList.test.tsx
+++ b/app/widgets/RecentPostLIst/ui/RecentPostList.test.tsx
@@ -1,13 +1,48 @@
+import { vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+vi.mock("@/shared", async () => {
+  const actual = await vi.importActual<typeof import("@/shared")>("@/shared");
+  return {
+    ...actual,
+    HOOKS: {
+      ...actual.HOOKS,
+      useGetRecentPostList: () => ({
+        data: [
+          {
+            id: "1",
+            title: "title",
+            content: "content",
+            createdAt: new Date(),
+            hashtagList: ["tag"],
+            writer: {
+              id: "1",
+              name: "writer",
+              email: "",
+              blog: { id: "1", domain: "domain" },
+            },
+          },
+        ],
+      }),
+    },
+  };
+});
 
 import { RecentPostList } from ".";
 
 describe("RecentPostList | ", () => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
   it("기본 렌더링이 정상적으로 이루어져야 합니다", () => {
     render(
       <MemoryRouter>
-        <RecentPostList />
+        <QueryClientProvider client={queryClient}>
+          <RecentPostList />
+        </QueryClientProvider>
       </MemoryRouter>
     );
     const recentPostList = screen.getByRole("listbox", {
@@ -19,7 +54,9 @@ describe("RecentPostList | ", () => {
   it("RecentPostItem이 렌더링 되어야 합니다", () => {
     render(
       <MemoryRouter>
-        <RecentPostList />
+        <QueryClientProvider client={queryClient}>
+          <RecentPostList />
+        </QueryClientProvider>
       </MemoryRouter>
     );
     const recentPostItems = screen.getAllByRole("feed", {


### PR DESCRIPTION
## Summary
- 게시글 카드가 기본 데이터로 렌더링되도록 개선
- 최근 게시글 리스트 테스트에서 React Query와 API 훅을 모킹해 실패 해결

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_685160fcb040832ab3f4e761f64d9d69