### PR TITLE
홈 진입 시 블로그 미보유 유저 자동 블로그 생성 다이얼로그 오픈 및 ReadUser 쿼리 구조 단순화

### DIFF
--- a/app/pages/home/index.tsx
+++ b/app/pages/home/index.tsx
@@ -2,17 +2,26 @@ import { CreateBlogDialog } from "@/features";
 import { LandingAbout, PopularPostList, RecentPostList } from "@/widgets";
 
 import { LandingIntro } from "@/widgets";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useGetBlogList } from "./api/useGetBlogList";
-import { ReadBlogQuery } from "@/shared/api/gql/graphql";
+import { HOOKS, useAuthStore } from "@/shared";
 
 export default function Home() {
   const [open, setOpen] = useState(false);
+  const { accessToken } = useAuthStore();
 
   const { data: blogList } = useGetBlogList({
     pageNumber: 1,
     limit: 2,
   });
+
+  const { data: self } = HOOKS.useSelf();
+
+  useEffect(() => {
+    if (!self?.blog || !accessToken) return;
+
+    setOpen(Boolean(!self.blog.id));
+  }, [self, accessToken]);
 
   return (
     <article className="mb-16 flex min-h-dvh justify-center">

--- a/app/shared/api/gql/gql.ts
+++ b/app/shared/api/gql/gql.ts
@@ -27,7 +27,7 @@ type Documents = {
     "\n  query ReadBlogList($input: ReadBlogListInputDto!) {\n    readBlogList(input: $input) {\n      id\n      name\n      domain\n      greeting\n      photo\n      introduction\n      skills\n      email\n      github\n      ownerId\n    }\n  }": typeof types.ReadBlogListDocument,
     "\n  query ReadPost($input: ReadPostInputDto!) {\n    readPost(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      writer {\n        id\n        name\n      }\n    }\n  }\n  ": typeof types.ReadPostDocument,
     "\n  query ReadPostList($input: ReadPostListInputDto!) {\n    readPostList(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      writer {\n        id\n        name\n        email\n        blog {\n          id\n          domain\n        }\n      }\n    }\n  }\n": typeof types.ReadPostListDocument,
-    "\n  query ReadUser {\n    readUser {\n      id\n      email\n      name\n      blog {\n        ...BlogFields\n      }\n    }\n  }\n  \n  fragment BlogFields on Blog {\n      id\n      domain\n    }\n  ": typeof types.ReadUserDocument,
+    "\n  query ReadUser {\n    readUser {\n      id\n      email\n      name\n      blog {\n        id\n      }\n    }\n  }\n": typeof types.ReadUserDocument,
 };
 const documents: Documents = {
     "\n  mutation CreateBlog($input: CreateBlogInputDto!) {\n    createBlog(input: $input) {\n      name\n      domain\n      greeting\n      photo\n      introduction\n      skills\n      email\n      github\n    }\n  }": types.CreateBlogDocument,
@@ -42,7 +42,7 @@ const documents: Documents = {
     "\n  query ReadBlogList($input: ReadBlogListInputDto!) {\n    readBlogList(input: $input) {\n      id\n      name\n      domain\n      greeting\n      photo\n      introduction\n      skills\n      email\n      github\n      ownerId\n    }\n  }": types.ReadBlogListDocument,
     "\n  query ReadPost($input: ReadPostInputDto!) {\n    readPost(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      writer {\n        id\n        name\n      }\n    }\n  }\n  ": types.ReadPostDocument,
     "\n  query ReadPostList($input: ReadPostListInputDto!) {\n    readPostList(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      writer {\n        id\n        name\n        email\n        blog {\n          id\n          domain\n        }\n      }\n    }\n  }\n": types.ReadPostListDocument,
-    "\n  query ReadUser {\n    readUser {\n      id\n      email\n      name\n      blog {\n        ...BlogFields\n      }\n    }\n  }\n  \n  fragment BlogFields on Blog {\n      id\n      domain\n    }\n  ": types.ReadUserDocument,
+    "\n  query ReadUser {\n    readUser {\n      id\n      email\n      name\n      blog {\n        id\n      }\n    }\n  }\n": types.ReadUserDocument,
 };
 
 /**
@@ -96,7 +96,7 @@ export function graphql(source: "\n  query ReadPostList($input: ReadPostListInpu
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query ReadUser {\n    readUser {\n      id\n      email\n      name\n      blog {\n        ...BlogFields\n      }\n    }\n  }\n  \n  fragment BlogFields on Blog {\n      id\n      domain\n    }\n  "): typeof import('./graphql').ReadUserDocument;
+export function graphql(source: "\n  query ReadUser {\n    readUser {\n      id\n      email\n      name\n      blog {\n        id\n      }\n    }\n  }\n"): typeof import('./graphql').ReadUserDocument;
 
 
 export function graphql(source: string) {

--- a/app/shared/api/gql/graphql.ts
+++ b/app/shared/api/gql/graphql.ts
@@ -710,12 +710,7 @@ export type ReadPostListQuery = { __typename?: 'Query', readPostList: Array<{ __
 export type ReadUserQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type ReadUserQuery = { __typename?: 'Query', readUser: { __typename?: 'User', id: string, email: string, name: string, blog?: (
-      { __typename?: 'Blog' }
-      & { ' $fragmentRefs'?: { 'BlogFieldsFragment': BlogFieldsFragment } }
-    ) | null } };
-
-export type BlogFieldsFragment = { __typename?: 'Blog', id: string, domain: string } & { ' $fragmentName'?: 'BlogFieldsFragment' };
+export type ReadUserQuery = { __typename?: 'Query', readUser: { __typename?: 'User', id: string, email: string, name: string, blog?: { __typename?: 'Blog', id: string } | null } };
 
 export class TypedDocumentString<TResult, TVariables>
   extends String
@@ -735,12 +730,7 @@ export class TypedDocumentString<TResult, TVariables>
     return this.value;
   }
 }
-export const BlogFieldsFragmentDoc = new TypedDocumentString(`
-    fragment BlogFields on Blog {
-  id
-  domain
-}
-    `, {"fragmentName":"BlogFields"}) as unknown as TypedDocumentString<BlogFieldsFragment, unknown>;
+
 export const CreateBlogDocument = new TypedDocumentString(`
     mutation CreateBlog($input: CreateBlogInputDto!) {
   createBlog(input: $input) {
@@ -898,11 +888,8 @@ export const ReadUserDocument = new TypedDocumentString(`
     email
     name
     blog {
-      ...BlogFields
+      id
     }
   }
 }
-    fragment BlogFields on Blog {
-  id
-  domain
-}`) as unknown as TypedDocumentString<ReadUserQuery, ReadUserQueryVariables>;
+    `) as unknown as TypedDocumentString<ReadUserQuery, ReadUserQueryVariables>;

--- a/app/shared/api/queries/readUser.ts
+++ b/app/shared/api/queries/readUser.ts
@@ -7,13 +7,8 @@ export const readUserQuery = graphql(`
       email
       name
       blog {
-        ...BlogFields
+        id
       }
     }
   }
-  
-  fragment BlogFields on Blog {
-      id
-      domain
-    }
-  `)
+`);


### PR DESCRIPTION
## 주요 변경 사항

- Home 페이지에서 로그인한 사용자가 블로그를 보유하지 않은 경우, 페이지 진입 시 자동으로 블로그 생성 다이얼로그(CreateBlogDialog)가 열리도록 useEffect 및 useSelf 훅 활용
- ReadUser GraphQL 쿼리에서 blog 필드의 반환값을 id만 포함하도록 단순화
  - 관련 타입, 쿼리, fragment, 코드 일괄 수정
  - 불필요한 BlogFields fragment 제거 및 관련 코드 정리
- 기타: 코드 일관성 및 불필요한 import/fragment 정리