### PR TITLE
홈 화면 블로그 생성 다이얼로그에 사용자명 전달 및 관련 컴포넌트 개선

### DIFF
--- a/app/features/CreateBlogDialog/ui/Content.tsx
+++ b/app/features/CreateBlogDialog/ui/Content.tsx
@@ -1,9 +1,13 @@
-export function Content() {
+interface Props {
+  userName: string;
+}
+
+export function Content({ userName }: Props) {
   return (
     <div>
-      <p className="whitespace-pre-line text-sm">
+      <p className="text-sm whitespace-pre-line">
         {`생성된 블로그가 없습니다. 블로그를 생성하고
-    FIXME: USER님만의 항해일지를 작성해 보세요🧭`}
+${userName}님만의 항해일지를 작성해 보세요🧭`}
       </p>
     </div>
   );

--- a/app/features/CreateBlogDialog/ui/Footer.tsx
+++ b/app/features/CreateBlogDialog/ui/Footer.tsx
@@ -1,12 +1,7 @@
 import { Dispatch, SetStateAction } from "react";
 import { Link } from "react-router";
 
-import {
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogFooter,
-  ROUTE,
-} from "@/shared";
+import { AlertDialogAction, AlertDialogFooter, ROUTE } from "@/shared";
 
 interface Props {
   setOpen: Dispatch<SetStateAction<boolean>>;
@@ -16,9 +11,6 @@ export function Footer({ setOpen }: Props) {
   return (
     <AlertDialogFooter>
       {/* 개발용 닫기 버튼 */}
-      <AlertDialogCancel onClick={() => setOpen(false)}>
-        FIXME: 개발용 닫기
-      </AlertDialogCancel>
       <Link to={`${ROUTE.MANAGE_BLOG}`}>
         <AlertDialogAction onClick={() => setOpen(false)}>
           블로그 만들기

--- a/app/features/CreateBlogDialog/ui/index.tsx
+++ b/app/features/CreateBlogDialog/ui/index.tsx
@@ -9,14 +9,15 @@ import { Header } from "./Header";
 interface Props {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
+  userName: string;
 }
 
-export function CreateBlogDialog({ open, setOpen }: Props) {
+export function CreateBlogDialog({ open, setOpen, userName }: Props) {
   return (
     <AlertDialog open={open}>
       <AlertDialogContent className="w-full !max-w-96">
         <Header />
-        <Content />
+        <Content userName={userName} />
         <Footer setOpen={setOpen} />
       </AlertDialogContent>
     </AlertDialog>

--- a/app/features/Editor/ui/index.tsx
+++ b/app/features/Editor/ui/index.tsx
@@ -15,7 +15,7 @@ export function Editor({ initialDoc, onChange, isHashtagInputFocused }: Props) {
     <div
       role="article"
       aria-label="editor-section"
-      className="relative mb-16 box-border flex h-full w-full flex-col gap-3"
+      className="relative box-border flex h-full w-full flex-col gap-3"
     >
       <div
         className={cn(
@@ -29,7 +29,7 @@ export function Editor({ initialDoc, onChange, isHashtagInputFocused }: Props) {
         className="w-full flex-1 cursor-text px-5"
         onClick={() => editorView?.focus()}
       >
-        <div ref={editorRef} />
+        <div ref={editorRef} className="h-full pb-16" />
       </div>
     </div>
   );

--- a/app/pages/home/index.tsx
+++ b/app/pages/home/index.tsx
@@ -2,9 +2,9 @@ import { CreateBlogDialog } from "@/features";
 import { LandingAbout, PopularPostList, RecentPostList } from "@/widgets";
 
 import { LandingIntro } from "@/widgets";
-import { useEffect, useState } from "react";
+import { Suspense, useEffect, useState } from "react";
 import { useGetBlogList } from "./api/useGetBlogList";
-import { HOOKS, useAuthStore } from "@/shared";
+import { HOOKS, Loading, useAuthStore } from "@/shared";
 
 export default function Home() {
   const [open, setOpen] = useState(false);
@@ -23,6 +23,8 @@ export default function Home() {
     setOpen(Boolean(!self.blog.id));
   }, [self, accessToken]);
 
+  if (self === undefined) return null;
+
   return (
     <article className="mb-16 flex min-h-dvh justify-center">
       <div className="flex w-full max-w-7xl flex-col gap-12 py-24">
@@ -35,7 +37,9 @@ export default function Home() {
           <RecentPostList />
         </div>
       </div>
-      <CreateBlogDialog open={open} setOpen={setOpen} />
+      <Suspense fallback={<Loading />}>
+        <CreateBlogDialog open={open} setOpen={setOpen} userName={self.name} />
+      </Suspense>
     </article>
   );
 }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,5 +1,4 @@
 import {
-  isRouteErrorResponse,
   Link,
   Links,
   Meta,
@@ -45,23 +44,23 @@ export default function App() {
     <QueryProvider>
       <Outlet />
       <ClientLayoutBody />
-      <Toaster />
+      <Toaster position="bottom-center" />
     </QueryProvider>
   );
 }
 
 export function ErrorBoundary({ error }: any) {
-  let message = "Error!";
-  let details = "서버와 연결할 수 없습니다 잠시 후 다시 시도해주세요";
   let stack: string | undefined;
 
-  if (isRouteErrorResponse(error)) {
-    message = error.status === 404 ? "404" : "Error!";
-    details =
-      error.status === 404 ? "요청하신 페이지를 찾을 수 없습니다" : details;
-  } else if (import.meta.env.DEV && error && error instanceof Error) {
-    message = "Error!";
-    details = error.message;
+  const message = error.status === 404 ? "404" : "Error!";
+  const details =
+    error.status === 404
+      ? "요청하신 페이지를 찾을 수 없습니다"
+      : error.message
+        ? error.message
+        : "서버와 연결할 수 없습니다 잠시 후 다시 시도해주세요";
+
+  if (import.meta.env.DEV && error && error instanceof Error) {
     stack = error.stack;
   }
 

--- a/app/shared/api/hooks/useSelf.ts
+++ b/app/shared/api/hooks/useSelf.ts
@@ -2,13 +2,23 @@ import { useQuery } from "@tanstack/react-query";
 
 import { QUERY_KEY } from "../../constant/queryKey";
 import { readUser } from "../queries";
+import { useAuthStore } from "../../stores/auth";
+import { ClientError } from "graphql-request";
 
 export function useSelf() {
+  const { accessToken } = useAuthStore();
+
   return useQuery({
     queryKey: QUERY_KEY.user.readUser(),
     queryFn: async () => {
+      if (!accessToken) return;
+
       const res = await readUser();
       return res.readUser;
     },
-  })
+    throwOnError: (error: ClientError["response"]) => {
+      throw new Error(error.errors?.[0].message);
+    },
+    enabled: Boolean(accessToken),
+  });
 }


### PR DESCRIPTION
홈 화면에서 블로그 미보유 시 노출되는 CreateBlogDialog에 userName prop을 전달하도록 수정하였습니다.
- CreateBlogDialog, Content 컴포넌트에 userName prop 추가 및 적용
- home/index.tsx에서 CreateBlogDialog 호출 시 userName 전달 및 Suspense로 감싸 로딩 처리 추가
- Footer 컴포넌트에서 불필요한 AlertDialogCancel(취소 버튼) 제거
- Editor 컴포넌트의 레이아웃 클래스 수정(h-full, pb-16 적용)
- root.tsx에서 Toaster 위치 bottom-center로 변경 및 ErrorBoundary 코드 개선
- useSelf 훅에서 accessToken 기반 enabled 처리 및 throwOnError 추가

이 변경으로 블로그 생성 안내 메시지에 사용자명을 동적으로 표시할 수 있으며, UX와 코드 일관성이 향상됩니다.