### PR TITLE
fix: CreateBlogDialog 및 Content 컴포넌트에서 userName prop을 optional로 변경

### DIFF
--- a/app/features/CreateBlogDialog/ui/Content.tsx
+++ b/app/features/CreateBlogDialog/ui/Content.tsx
@@ -1,5 +1,5 @@
 interface Props {
-  userName: string;
+  userName?: string;
 }
 
 export function Content({ userName }: Props) {
@@ -7,7 +7,7 @@ export function Content({ userName }: Props) {
     <div>
       <p className="text-sm whitespace-pre-line">
         {`생성된 블로그가 없습니다. 블로그를 생성하고
-${userName}님만의 항해일지를 작성해 보세요🧭`}
+${userName ?? "항해자"}님만의 항해일지를 작성해 보세요🧭`}
       </p>
     </div>
   );

--- a/app/features/CreateBlogDialog/ui/index.tsx
+++ b/app/features/CreateBlogDialog/ui/index.tsx
@@ -9,7 +9,7 @@ import { Header } from "./Header";
 interface Props {
   open: boolean;
   setOpen: Dispatch<SetStateAction<boolean>>;
-  userName: string;
+  userName?: string;
 }
 
 export function CreateBlogDialog({ open, setOpen, userName }: Props) {

--- a/app/pages/home/index.tsx
+++ b/app/pages/home/index.tsx
@@ -23,8 +23,6 @@ export default function Home() {
     setOpen(Boolean(!self.blog.id));
   }, [self, accessToken]);
 
-  if (self === undefined) return null;
-
   return (
     <article className="mb-16 flex min-h-dvh justify-center">
       <div className="flex w-full max-w-7xl flex-col gap-12 py-24">
@@ -38,7 +36,7 @@ export default function Home() {
         </div>
       </div>
       <Suspense fallback={<Loading />}>
-        <CreateBlogDialog open={open} setOpen={setOpen} userName={self.name} />
+        <CreateBlogDialog open={open} setOpen={setOpen} userName={self?.name} />
       </Suspense>
     </article>
   );


### PR DESCRIPTION
- CreateBlogDialog, Content 컴포넌트의 userName prop을 선택적으로 받을 수 있도록 타입 수정
- home 페이지에서 self가 undefined일 때도 CreateBlogDialog가 정상적으로 동작하도록 userName 전달 방식 개선
- Content 컴포넌트에서 userName이 없을 경우 기본값이 표시되도록 처리