### PR TITLE
feat: 게시글 목록 조회 및 무한 스크롤 기능 개선

### DIFF
--- a/app/entities/HorizontalPostCard/ui/index.tsx
+++ b/app/entities/HorizontalPostCard/ui/index.tsx
@@ -1,15 +1,20 @@
+import { mdToPlanText, ReadPostListQuery } from "@/shared";
+import { format } from "date-fns";
 import { Link } from "react-router";
 
 interface Props {
-  username?: string;
-  postId?: string;
+  post: ReadPostListQuery["readPostList"][number];
 }
 
-export function HorizontalPostCard({ username, postId }: Props) {
+export function HorizontalPostCard({ post }: Props) {
   return (
-    <li role="feed" aria-label="horizontal-post-card" className="flex w-full">
+    <li
+      role="feed"
+      aria-label="horizontal-post-card"
+      className="group flex w-full"
+    >
       <Link
-        to={`/${username}/${postId}`}
+        to={`/${post.writer.blog?.domain}/${post.id}`}
         className="flex w-full flex-col overflow-hidden rounded-lg border transition hover:shadow-lg md:flex-row"
       >
         {/* 썸네일 */}
@@ -20,25 +25,27 @@ export function HorizontalPostCard({ username, postId }: Props) {
           <div className="flex flex-col gap-2">
             <div className="mb-2 flex items-center gap-4">
               <span className="text-sm text-gray-500">
-                {new Date().toLocaleDateString("ko-KR")}
+                {format(post.createdAt, "yyyy년 MM월 dd일")}
               </span>
-              <span className="text-sm text-gray-500">• 작성자 누구누구씨</span>
+              <span className="text-sm text-gray-500">
+                • {post.writer.name}
+              </span>
             </div>
-            <h4 className="mb-2 line-clamp-2 text-xl font-bold">
-              인기 게시글 제목이에요 인기 게시글 제목이에요 인기 게시글
-              제목이에요
+            <h4 className="group-hover:text-primary mb-2 line-clamp-2 text-xl font-bold group-hover:transition-colors">
+              {post.title}
             </h4>
             <p className="mb-4 line-clamp-3 text-gray-600">
-              인기 게시글 내용이에요 인기 게시글 내용이에요 인기 게시글
-              내용이에요 인기 게시글 내용이에요 인기 게시글 내용이에요
+              {mdToPlanText(post.content)}
             </p>
             <div className="flex gap-2">
-              <span className="rounded bg-gray-100 px-2 py-1 text-xs">
-                React
-              </span>
-              <span className="rounded bg-gray-100 px-2 py-1 text-xs">
-                Next.js
-              </span>
+              {post.hashtagList?.map((tag, index) => (
+                <span
+                  key={`${tag}_${index}`}
+                  className="rounded bg-gray-100 px-2 py-1 text-xs"
+                >
+                  {tag}
+                </span>
+              ))}
             </div>
           </div>
         </div>

--- a/app/pages/blog/post/index.tsx
+++ b/app/pages/blog/post/index.tsx
@@ -94,7 +94,7 @@ export default function Post() {
                 {format(post.createdAt, "yyyy년 MM월 dd일")}
               </p>
             </div>
-            {/* 카테고리 */}
+            {/* 해시태그 */}
             <div className="flex items-end justify-between">
               <div className="flex flex-wrap gap-x-4 gap-y-2">
                 {post.hashtagList?.map((hashtag, index) => (

--- a/app/pages/editor/index.tsx
+++ b/app/pages/editor/index.tsx
@@ -72,7 +72,7 @@ export default function EditorPage() {
     setHashtag(e.target.value);
   };
 
-  /** 카테고리 입력 키보드 함수 */
+  /** 해시태그 입력 키보드 함수 */
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
     const key = e.code;
 

--- a/app/shared/api/hooks/index.ts
+++ b/app/shared/api/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useSelf } from "./useSelf";
-export { useGetRecentPostList } from "./useGetRecentPostList";
+export { useGetPostList } from "./useGetPostList";
 export { useGetBlogByDomain } from "./useGetBlogByDomain";
 export { useGetPost } from "./useGetPost";
+export { useDebounceGetPostList } from "./useGetPostList";

--- a/app/shared/api/hooks/useGetPostList.ts
+++ b/app/shared/api/hooks/useGetPostList.ts
@@ -1,8 +1,9 @@
 import { QUERIES, QUERY_KEY, ReadPostListInputDto } from "@/shared";
 import { useQuery } from "@tanstack/react-query";
 import { ClientError } from "graphql-request";
+import { useEffect, useState } from "react";
 
-export function useGetRecentPostList(params?: ReadPostListInputDto) {
+export function useGetPostList(params?: ReadPostListInputDto) {
   return useQuery({
     queryKey: QUERY_KEY.post.readPostList(params),
     queryFn: async () => {
@@ -15,4 +16,18 @@ export function useGetRecentPostList(params?: ReadPostListInputDto) {
     },
     enabled: Boolean(params),
   });
+}
+
+export function useDebounceGetPostList(params?: ReadPostListInputDto) {
+  const [debouncedParams, setDebouncedParams] = useState(params);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setDebouncedParams(params);
+    }, 1000);
+
+    return () => clearTimeout(timeout);
+  }, [params]);
+
+  return useGetPostList(debouncedParams);
 }

--- a/app/widgets/BlogForm/ui/index.tsx
+++ b/app/widgets/BlogForm/ui/index.tsx
@@ -100,7 +100,8 @@ export function BlogForm() {
 
       createBlog(body, {
         onSuccess: (res) => {
-          navigate(res.domain);
+          toast.success("블로그가 생성되었습니다.");
+          navigate(ROUTE.BLOG.replace(":domain", res.domain));
         },
       });
     },

--- a/app/widgets/PopularPostList/ui/index.tsx
+++ b/app/widgets/PopularPostList/ui/index.tsx
@@ -1,6 +1,17 @@
 import { HorizontalPostCard } from "@/entities";
+import { Loading, Sort_Option } from "@/shared";
+import { HOOKS } from "@/shared";
+import { Suspense } from "react";
 
 export function PopularPostList() {
+  const { data: popularPostList } = HOOKS.useGetPostList({
+    sortOption: Sort_Option.ViewCount,
+    limit: 10,
+    pageNumber: 1,
+  });
+
+  if (popularPostList === undefined) return null;
+
   return (
     <div
       role="listbox"
@@ -9,16 +20,11 @@ export function PopularPostList() {
     >
       <h2 className="text-primary text-2xl font-bold">인기 게시글</h2>
       <ul className="flex flex-col gap-5">
-        <HorizontalPostCard />
-        <HorizontalPostCard />
-        <HorizontalPostCard />
-        <HorizontalPostCard />
-        <HorizontalPostCard />
-        <HorizontalPostCard />
-        <HorizontalPostCard />
-        <HorizontalPostCard />
-        <HorizontalPostCard />
-        <HorizontalPostCard />
+        <Suspense fallback={<Loading />}>
+          {popularPostList.map((post) => (
+            <HorizontalPostCard key={post.id} post={post} />
+          ))}
+        </Suspense>
       </ul>
     </div>
   );

--- a/app/widgets/RecentPostLIst/ui/index.tsx
+++ b/app/widgets/RecentPostLIst/ui/index.tsx
@@ -4,7 +4,7 @@ import { HOOKS } from "@/shared";
 import { Suspense } from "react";
 
 export function RecentPostList() {
-  const { data: recentPostList } = HOOKS.useGetRecentPostList({
+  const { data: recentPostList } = HOOKS.useGetPostList({
     sortOption: Sort_Option.Newest,
     limit: 10,
     pageNumber: 1,


### PR DESCRIPTION
## 변경사항
#### 게시글 목록 조회 훅 개선
   - 기존의 useGetRecentPostList 훅을 useGetPostList로 통합 및 확장하였습니다.
   - useDebounceGetPostList 훅을 추가하여, 게시글 목록 조회 시 디바운스 기능을 적용하였습니다.

#### 컴포넌트 인터페이스 및 렌더링 방식 변경
   - HorizontalPostCard 컴포넌트가 username, postId가 아닌 post 객체 전체를 받아 렌더링하도록 인터페이스를 변경하였습니다.
   - Blog 페이지에서 postList 상태를 관리하며, IntersectionObserver를 활용한 무한 스크롤 방식으로 게시글을 불러오도록 개선하였습니다.
   - 인기 게시글(인기글), 최신 게시글(최신글) 위젯에서도 새로운 훅과 컴포넌트 인터페이스를 반영하였습니다.

#### 기타 개선 사항
   - 블로그 생성 후 라우팅 경로를 ROUTE.BLOG를 활용하여 일관성 있게 변경하였고, 성공 토스트 메시지를 추가하였습니다.
   - 불필요한 더미 데이터 및 하드코딩된 부분을 제거하고, 코드 가독성을 높이기 위해 정리하였습니다.
   - 관련 import/export 및 네이밍을 일괄적으로 수정하였습니다.