### PR TITLE
테스트 실패 원인 수정

### DIFF
--- a/app/widgets/LandingAbout/ui/index.tsx
+++ b/app/widgets/LandingAbout/ui/index.tsx
@@ -54,7 +54,7 @@ export function LandingAbout({ right, blog }: Props) {
           role="article"
           aria-label="about-section"
           className={cn(
-            "group flex gap-0 overflow-hidden rounded-lg border transition hover:shadow-lg",
+            "group flex flex-row gap-0 overflow-hidden rounded-lg border transition hover:shadow-lg",
             right && "flex-row-reverse"
           )}
         >

--- a/app/widgets/ManageGNB/ui/ManageGNB.test.tsx
+++ b/app/widgets/ManageGNB/ui/ManageGNB.test.tsx
@@ -12,14 +12,20 @@ vi.mock("react-router", async () => {
 
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import { ManageGNB } from ".";
 
 describe("ManageGNB | ", () => {
   it("렌더링이 정상적으로 이루어져야 합니다", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
     render(
       <MemoryRouter>
-        <ManageGNB />
+        <QueryClientProvider client={queryClient}>
+          <ManageGNB />
+        </QueryClientProvider>
       </MemoryRouter>
     );
     expect(screen.getByTestId("ManageGNB")).toBeInTheDocument();


### PR DESCRIPTION
## 변경 내용
- `LandingAbout`의 기본 방향 클래스를 `flex-row`로 명시하여 테스트 실패 수정
- `ManageGNB` 테스트에서 `QueryClientProvider`를 적용해 React Query 설정 추가

## 테스트 결과
- `pnpm vitest run` 실행 결과 모든 테스트 통과 확인

------
https://chatgpt.com/codex/tasks/task_e_6860f423022c832aba3fd1552cdc7e90