### PR TITLE
Fix test env variable error

### DIFF
--- a/app/shared/api/axios.ts
+++ b/app/shared/api/axios.ts
@@ -8,8 +8,13 @@ import { useCallback } from "react";
 import { getErrorMessage } from "../lib/getErrorMessage";
 import { toast } from "sonner";
 
+const baseURL = (import.meta.env?.VITE_PUBLIC_API_ENDPOINT || "").replace(
+  "/graphql",
+  ""
+);
+
 export const instance: AxiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_PUBLIC_API_ENDPOINT.replace("/graphql", ""),
+  baseURL,
   headers: {
     "Content-Type": "multipart/form-data",
   },


### PR DESCRIPTION
## Summary
- 테스트 실행 시 `import.meta.env.VITE_PUBLIC_API_ENDPOINT` 가 정의되지 않아 발생하던 오류를 수정했습니다.
- 환경 변수가 없을 때도 기본값을 사용하도록 `axios` 인스턴스 초기화 로직을 변경했습니다.

## Testing
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686138e42704832a9fdaf1d851d3f248