### PR TITLE
툴바 기능 개선 및 해시태그/이력서/이미지 업로드 주요 기능 개선

### DIFF
--- a/app/features/Editor/model/useToolbar.tsx
+++ b/app/features/Editor/model/useToolbar.tsx
@@ -252,11 +252,26 @@ export function useToolbar({ editorView }: Props) {
         return;
       },
       link: () => {
-        //TODO: 링크 추가방식 생각해봐야함
-        return console.log("link");
+        const range = editorView.state.selection.main;
+        const linkMarkdown = `[링크](URL을 입력해 주세요)`;
+        // 삽입 후 selection 범위 계산: 괄호 위치를 기준으로 정확히 계산
+        const insertFrom = range.from;
+        const openParen = linkMarkdown.indexOf("(");
+        const closeParen = linkMarkdown.indexOf(")");
+        const urlStart = insertFrom + openParen + 1;
+        const urlEnd = insertFrom + closeParen;
+        editorView.dispatch({
+          changes: {
+            from: range.from,
+            to: range.to,
+            insert: linkMarkdown,
+          },
+          selection: EditorSelection.range(urlStart, urlEnd),
+        });
+        return;
       },
       image: () => {
-        //TODO: 이미지 업로드 방식 생각해봐야함
+        /** 이미지 업로드 api를 통해 cloud flare images에 업로드 후 받아온 url을 입력함 */
         const fileInput = document.createElement("input");
         fileInput.type = "file";
         fileInput.accept = "image/*";

--- a/app/pages/blog/api/useGetHashtagList.ts
+++ b/app/pages/blog/api/useGetHashtagList.ts
@@ -1,0 +1,13 @@
+import { QUERIES, QUERY_KEY } from "@/shared";
+import { useQuery } from "@tanstack/react-query";
+
+export function useGetHashtagList() {
+  return useQuery({
+    queryKey: QUERY_KEY.hashtag.readHashtagList(),
+    queryFn: async () => {
+      const data = await QUERIES.readHashtagList();
+
+      return data.readHashtagList;
+    },
+  });
+}

--- a/app/pages/blog/resume/index.tsx
+++ b/app/pages/blog/resume/index.tsx
@@ -10,11 +10,15 @@ import { useParams } from "react-router";
 
 export default function Resume() {
   const { resumeId } = useParams();
-  const { data: resume } = HOOKS.useGetResume({
-    id: resumeId,
-  });
+  const { data: resume } = HOOKS.useGetResume(
+    resumeId
+      ? {
+          id: resumeId,
+        }
+      : undefined
+  );
 
-  if (!resume) throw new Error("이력서가 존재하지 않습니다.", { cause: 404 });
+  if (!resume) return null;
 
   const { educationList, careerList, projectList, portfolioList } = resume;
 
@@ -42,8 +46,8 @@ export default function Resume() {
             <ul className="flex flex-col gap-4">
               {educationList &&
                 educationList.length > 0 &&
-                educationList.map((item) => (
-                  <ResumeEducationItem key={item.id} item={item} />
+                educationList.map((item, index) => (
+                  <ResumeEducationItem key={index} item={item} />
                 ))}
             </ul>
           </div>
@@ -54,8 +58,8 @@ export default function Resume() {
             <ul className="flex flex-col gap-4">
               {careerList &&
                 careerList.length > 0 &&
-                careerList.map((item) => (
-                  <ResumeCareerItem key={item.id} item={item} />
+                careerList.map((item, index) => (
+                  <ResumeCareerItem key={index} item={item} />
                 ))}
             </ul>
           </div>
@@ -66,8 +70,8 @@ export default function Resume() {
             <ul className="flex flex-col gap-4">
               {projectList &&
                 projectList.length > 0 &&
-                projectList.map((item) => (
-                  <ResumeProjectItem key={item.id} item={item} />
+                projectList.map((item, index) => (
+                  <ResumeProjectItem key={index} item={item} />
                 ))}
             </ul>
           </div>
@@ -78,9 +82,9 @@ export default function Resume() {
               <div className="flex flex-col gap-4">
                 <h3 className="text-primary text-3xl font-bold">포트폴리오</h3>
                 <ul className="flex flex-col gap-4">
-                  {portfolioList.flatMap((item) =>
+                  {portfolioList.flatMap((item, index) =>
                     item.url ? (
-                      <ResumePortfolioItem key={item.id} item={item} />
+                      <ResumePortfolioItem key={index} item={item} />
                     ) : (
                       []
                     )

--- a/app/shared/api/gql/gql.ts
+++ b/app/shared/api/gql/gql.ts
@@ -27,7 +27,8 @@ type Documents = {
     "\n  query Login($input: LoginInputDto!) {\n    login(input: $input)\n  }\n": typeof types.LoginDocument,
     "\n  query ReadBlog($input: ReadBlogInputDto!) {\n    readBlog(input: $input) {\n      id\n      name\n      domain\n      greeting\n      photo\n      introduction\n      skills\n      email\n      github\n      ownerId\n      resumeId\n    }\n  }\n": typeof types.ReadBlogDocument,
     "\n  query ReadBlogList($input: ReadBlogListInputDto!) {\n    readBlogList(input: $input) {\n      id\n      name\n      domain\n      greeting\n      photo\n      introduction\n      skills\n      email\n      github\n      ownerId\n    }\n  }": typeof types.ReadBlogListDocument,
-    "\n  query ReadPost($input: ReadPostInputDto!) {\n    readPost(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      viewCount\n      owner {\n        id\n        name\n      }\n    }\n  }\n": typeof types.ReadPostDocument,
+    "\n  query ReadHashtagList {\n    readHashtagList\n  }\n": typeof types.ReadHashtagListDocument,
+    "\n  query ReadPost($input: ReadPostInputDto!) {\n    readPost(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      owner {\n        id\n        name\n      }\n    }\n  }\n": typeof types.ReadPostDocument,
     "\n  query ReadPostList($input: ReadPostListInputDto!) {\n    readPostList(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      owner {\n        id\n        name\n        email\n        blog {\n          id\n          domain\n        }\n      }\n    }\n  }\n": typeof types.ReadPostListDocument,
     "\n  query ReadResume($input: ReadResumeInputDto!) {\n    readResume(input: $input) {\n      id\n      owner {\n        name\n        email\n      }\n      educationList {\n        order\n        name\n        major\n        grade\n        standardGrade\n        graduationStatus\n        startAt\n        endAt\n      }\n      careerList {\n        order\n        company\n        department\n        position\n        description\n        startAt\n        endAt\n      }\n      projectList {\n        order\n        name\n        personnel\n        skillList\n        description\n        startAt\n        endAt\n      }\n      portfolioList {\n        order\n        url\n      }\n    }\n  }\n": typeof types.ReadResumeDocument,
     "\n  query ReadUser {\n    readUser {\n      id\n      email\n      name\n      blog {\n        id\n      }\n    }\n  }\n": typeof types.ReadUserDocument,
@@ -45,7 +46,8 @@ const documents: Documents = {
     "\n  query Login($input: LoginInputDto!) {\n    login(input: $input)\n  }\n": types.LoginDocument,
     "\n  query ReadBlog($input: ReadBlogInputDto!) {\n    readBlog(input: $input) {\n      id\n      name\n      domain\n      greeting\n      photo\n      introduction\n      skills\n      email\n      github\n      ownerId\n      resumeId\n    }\n  }\n": types.ReadBlogDocument,
     "\n  query ReadBlogList($input: ReadBlogListInputDto!) {\n    readBlogList(input: $input) {\n      id\n      name\n      domain\n      greeting\n      photo\n      introduction\n      skills\n      email\n      github\n      ownerId\n    }\n  }": types.ReadBlogListDocument,
-    "\n  query ReadPost($input: ReadPostInputDto!) {\n    readPost(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      viewCount\n      owner {\n        id\n        name\n      }\n    }\n  }\n": types.ReadPostDocument,
+    "\n  query ReadHashtagList {\n    readHashtagList\n  }\n": types.ReadHashtagListDocument,
+    "\n  query ReadPost($input: ReadPostInputDto!) {\n    readPost(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      owner {\n        id\n        name\n      }\n    }\n  }\n": types.ReadPostDocument,
     "\n  query ReadPostList($input: ReadPostListInputDto!) {\n    readPostList(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      owner {\n        id\n        name\n        email\n        blog {\n          id\n          domain\n        }\n      }\n    }\n  }\n": types.ReadPostListDocument,
     "\n  query ReadResume($input: ReadResumeInputDto!) {\n    readResume(input: $input) {\n      id\n      owner {\n        name\n        email\n      }\n      educationList {\n        order\n        name\n        major\n        grade\n        standardGrade\n        graduationStatus\n        startAt\n        endAt\n      }\n      careerList {\n        order\n        company\n        department\n        position\n        description\n        startAt\n        endAt\n      }\n      projectList {\n        order\n        name\n        personnel\n        skillList\n        description\n        startAt\n        endAt\n      }\n      portfolioList {\n        order\n        url\n      }\n    }\n  }\n": types.ReadResumeDocument,
     "\n  query ReadUser {\n    readUser {\n      id\n      email\n      name\n      blog {\n        id\n      }\n    }\n  }\n": types.ReadUserDocument,
@@ -102,7 +104,11 @@ export function graphql(source: "\n  query ReadBlogList($input: ReadBlogListInpu
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */
-export function graphql(source: "\n  query ReadPost($input: ReadPostInputDto!) {\n    readPost(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      viewCount\n      owner {\n        id\n        name\n      }\n    }\n  }\n"): typeof import('./graphql').ReadPostDocument;
+export function graphql(source: "\n  query ReadHashtagList {\n    readHashtagList\n  }\n"): typeof import('./graphql').ReadHashtagListDocument;
+/**
+ * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
+ */
+export function graphql(source: "\n  query ReadPost($input: ReadPostInputDto!) {\n    readPost(input: $input) {\n      id\n      title\n      content\n      hashtagList\n      createdAt\n      owner {\n        id\n        name\n      }\n    }\n  }\n"): typeof import('./graphql').ReadPostDocument;
 /**
  * The graphql function is used to parse GraphQL queries into a document that can be used by GraphQL clients.
  */

--- a/app/shared/api/gql/graphql.ts
+++ b/app/shared/api/gql/graphql.ts
@@ -666,12 +666,17 @@ export type ReadBlogListQueryVariables = Exact<{
 
 export type ReadBlogListQuery = { __typename?: 'Query', readBlogList: Array<{ __typename?: 'Blog', id: string, name: string, domain: string, greeting: string, photo?: string | null, introduction: string, skills?: Array<string> | null, email?: string | null, github?: string | null, ownerId: string }> };
 
+export type ReadHashtagListQueryVariables = Exact<{ [key: string]: never; }>;
+
+
+export type ReadHashtagListQuery = { __typename?: 'Query', readHashtagList: Array<string> };
+
 export type ReadPostQueryVariables = Exact<{
   input: ReadPostInputDto;
 }>;
 
 
-export type ReadPostQuery = { __typename?: 'Query', readPost: { __typename?: 'Post', id: string, title: string, content: string, hashtagList?: Array<string> | null, createdAt: any, viewCount: number, owner: { __typename?: 'User', id: string, name: string } } };
+export type ReadPostQuery = { __typename?: 'Query', readPost: { __typename?: 'Post', id: string, title: string, content: string, hashtagList?: Array<string> | null, createdAt: any, owner: { __typename?: 'User', id: string, name: string } } };
 
 export type ReadPostListQueryVariables = Exact<{
   input: ReadPostListInputDto;
@@ -842,6 +847,11 @@ export const ReadBlogListDocument = new TypedDocumentString(`
   }
 }
     `) as unknown as TypedDocumentString<ReadBlogListQuery, ReadBlogListQueryVariables>;
+export const ReadHashtagListDocument = new TypedDocumentString(`
+    query ReadHashtagList {
+  readHashtagList
+}
+    `) as unknown as TypedDocumentString<ReadHashtagListQuery, ReadHashtagListQueryVariables>;
 export const ReadPostDocument = new TypedDocumentString(`
     query ReadPost($input: ReadPostInputDto!) {
   readPost(input: $input) {
@@ -850,7 +860,6 @@ export const ReadPostDocument = new TypedDocumentString(`
     content
     hashtagList
     createdAt
-    viewCount
     owner {
       id
       name

--- a/app/shared/api/hooks/useGetResume.ts
+++ b/app/shared/api/hooks/useGetResume.ts
@@ -1,15 +1,15 @@
-import { QUERIES, ReadResumeInputDto } from "@/shared";
-import { QUERY_KEY } from "@/shared/constant/queryKey";
+import { QUERY_KEY } from "../../constant/queryKey";
 import { useQuery } from "@tanstack/react-query";
 import { ClientError } from "graphql-request";
+import { readResume } from "../queries";
+import { ReadResumeInputDto } from "../gql/graphql";
 
 export function useGetResume(params?: ReadResumeInputDto) {
   return useQuery({
     queryKey: QUERY_KEY.resume.readResume(params),
     queryFn: async () => {
-      console.log(params);
       if (!params) return;
-      const res = await QUERIES.readResume(params);
+      const res = await readResume(params);
 
       return res.readResume;
     },

--- a/app/shared/api/mutations/index.ts
+++ b/app/shared/api/mutations/index.ts
@@ -74,7 +74,4 @@ export async function uploadProfileImage(formData: FormData) {
   return await axiosInstance.post<string>("/upload/profile-image", formData);
 }
 
-/** 게시글 이미지 업로드 */
-export async function uploadPostImage(formData: FormData) {
-  return await axiosInstance.post<string>("/upload/post-image", formData);
-}
+/** 게시글 이미지 업로드는 imageUpload 함수를 통해 업로드함 */

--- a/app/shared/api/queries/index.ts
+++ b/app/shared/api/queries/index.ts
@@ -5,6 +5,7 @@ import {
   ReadBlogListInputDto,
   ReadBlogListQuery,
   ReadBlogQuery,
+  ReadHashtagListQuery,
   ReadPostInputDto,
   ReadPostListInputDto,
   ReadPostListQuery,
@@ -21,6 +22,7 @@ import { readPostQuery } from "./readPost";
 import { readPostListQuery } from "./readPostList";
 import { readUserQuery } from "./readUser";
 import { readResumeQuery } from "./readResume";
+import { readHashtagListQuery } from "./readHashtagList";
 
 /** 로그인 */
 export async function login(input: LoginInputDto) {
@@ -57,4 +59,9 @@ export async function readBlogList(input: ReadBlogListInputDto) {
 /** 이력서 조회 */
 export async function readResume(input: ReadResumeInputDto) {
   return await instance<ReadResumeQuery>(readResumeQuery, { input });
+}
+
+/** 해시태그 목록 조회 */
+export async function readHashtagList() {
+  return await instance<ReadHashtagListQuery>(readHashtagListQuery);
 }

--- a/app/shared/api/queries/readHashtagList.ts
+++ b/app/shared/api/queries/readHashtagList.ts
@@ -1,0 +1,7 @@
+import { graphql } from "../gql";
+
+export const readHashtagListQuery = graphql(`
+  query ReadHashtagList {
+    readHashtagList
+  }
+`);

--- a/app/shared/api/queries/readPost.ts
+++ b/app/shared/api/queries/readPost.ts
@@ -8,7 +8,6 @@ export const readPostQuery = graphql(`
       content
       hashtagList
       createdAt
-      viewCount
       owner {
         id
         name

--- a/app/shared/constant/queryKey.ts
+++ b/app/shared/constant/queryKey.ts
@@ -8,6 +8,7 @@ export const ROOT_KEY = {
   blog: "blog",
   post: "post",
   resume: "resume",
+  hashtag: "hashtag",
 };
 
 export const QUERY_KEY = {
@@ -43,5 +44,8 @@ export const QUERY_KEY = {
       "readResume",
       params,
     ],
+  },
+  hashtag: {
+    readHashtagList: () => [ROOT_KEY.hashtag, "readHashtagList"],
   },
 };

--- a/app/shared/lib/imageUpload/index.ts
+++ b/app/shared/lib/imageUpload/index.ts
@@ -1,25 +1,28 @@
+import { instance } from "../../api/axios";
 import { EditorView } from "@codemirror/view";
+import { EditorSelection } from "@codemirror/state";
 
 export async function imageUpload(file: File, editorView: EditorView) {
   const formData = new FormData();
-  formData.append("image", file);
+  formData.append("file", file);
 
   try {
-    // TODO: 이미지 업로드 api 연결 필요
-    const response = await fetch("/api", {
-      method: "POST",
-      body: formData,
-    });
-    const data = await response.json();
-    const imageUrl = data.imageUrl;
+    const response = await instance.post<string>(
+      "/upload/post-image",
+      formData
+    );
+    const imageUrl = response.data;
     const imageMarkdown = `![이미지 설명](${imageUrl})`;
     const range = editorView.state.selection.main;
+    const descStart = range.from + 2;
+    const descEnd = descStart + 6;
 
     return editorView.dispatch({
       changes: {
         from: range.from,
         insert: imageMarkdown,
       },
+      selection: EditorSelection.range(descStart, descEnd),
     });
   } catch (error) {
     console.error("이미지 업로드에 실패했습니다", error);
@@ -29,6 +32,7 @@ export async function imageUpload(file: File, editorView: EditorView) {
         from: range.from,
         insert: `![이미지 업로드에 실패했습니다]()`,
       },
+      selection: EditorSelection.range(range.from + 2, range.from + 2 + 15),
     });
   }
 }

--- a/app/shared/ui/Hashtag/index.tsx
+++ b/app/shared/ui/Hashtag/index.tsx
@@ -1,13 +1,19 @@
+import { cn } from "../../lib/cn";
+
 interface Props {
   hashtag: string;
+  isSelected?: boolean;
   total?: number;
   onClick?: () => void;
 }
 
-export function Hashtag({ hashtag, total, onClick }: Props) {
+export function Hashtag({ hashtag, total, onClick, isSelected }: Props) {
   return (
     <button
-      className="bg-background hover:bg-accent inline-flex flex-shrink-0 cursor-pointer items-center rounded-full px-3 py-1 text-sm transition-colors not-xl:p-1"
+      className={cn(
+        isSelected ? "bg-accent" : "bg-background",
+        "hover:bg-accent inline-flex flex-shrink-0 cursor-pointer items-center rounded-full px-3 py-1 text-sm transition-colors not-xl:p-1"
+      )}
       onClick={onClick}
       type="button"
     >


### PR DESCRIPTION
## 변경사항
#### 툴바/에디터 기능 개선
- 툴바의 링크 삽입 기능 구현: 선택 영역에 마크다운 링크 템플릿 삽입 후 URL 입력 부분 자동 선택 처리
- 툴바의 이미지 삽입 기능에서 input file 생성 및 이미지 업로드 함수 호출 구조로 변경

#### 해시태그 동적 조회 및 필터링 기능 개선
- useGetHashtagList 훅, readHashtagList 쿼리, 관련 타입, 상수, 쿼리키 등 복구
- 블로그 메인 페이지에서 해시태그 동적 조회 및 선택(필터) 기능 복구
  - Hashtag 컴포넌트에 isSelected prop 및 관련 스타일, cn 함수 import 복구
  - 해시태그 목록을 API에서 받아와 동적으로 렌더링, 선택/필터 핸들러 및 상태 복구

#### 이력서(Resume) 페이지 key 및 쿼리 구조 개선
- 이력서 조회 훅(useGetResume)에서 params 구조 및 쿼리 호출 방식 복구
- 각 리스트(학력, 경력, 프로젝트, 포트폴리오) 렌더링 시 key를 index로 복구
- 이력서 데이터가 없을 때 return null로 복구

#### 이미지 업로드 및 API 연동 방식 개선
- imageUpload 함수에서 axios 인스턴스 사용 방식으로 복구, formData 필드명 'file'로 변경
- 업로드 성공 시 마크다운 이미지 템플릿 삽입 및 alt 텍스트 부분 자동 선택 처리
- 업로드 실패 시 에러 메시지 출력 및 실패 마크다운 템플릿 삽입, alt 텍스트 부분 자동 선택 처리
- 게시글 이미지 업로드 API 함수(uploadPostImage) 주석 처리